### PR TITLE
Update ods.js

### DIFF
--- a/ods.js
+++ b/ods.js
@@ -7,7 +7,7 @@ var ODS = {};
 var get_utils = function() {
 	if(typeof XLSX !== 'undefined') return XLSX.utils;
 	if(typeof module !== "undefined" && typeof require !== 'undefined') try {
-		return require('../' + 'xlsx').utils;
+		return require('./' + 'xlsx').utils;
 	} catch(e) {
 		try { return require('./' + 'xlsx').utils; }
 		catch(ee) { return require('xl' + 'sx').utils; }


### PR DESCRIPTION
require('../' + 'xlsx') needed replaced with require('./' + 'xlsx') to stop a node error when trying to find the tempa-xlsx