### PR TITLE
Bug fix Uncaught TypeError: jszip is not a constructor

### DIFF
--- a/xlsx.js
+++ b/xlsx.js
@@ -11740,6 +11740,7 @@ function write_zip(wb, opts) {
 		coreprops: [], extprops: [], custprops: [], strs:[], comments: [], vba: [],
 		TODO:[], rels:[], xmlns: "" };
 	fix_write_opts(opts = opts || {});
+	if(typeof jszip === 'undefined') jszip = require('js'+'zip');
 	var zip = new jszip();
 	var f = "", rId = 0;
 


### PR DESCRIPTION
Bug fix Uncaught TypeError: jszip is not a constructor